### PR TITLE
Fix incorrect Turkish notice

### DIFF
--- a/components/address-selector.tsx
+++ b/components/address-selector.tsx
@@ -968,9 +968,9 @@ export default function DeliveryMethodSelector() {
                         !
                       </span>
                     </div>
-                    <p className="text-sm text-orange-800">
-                      Şiparisiniz seçtiğiniz adrese teslim edilecektir.
-                    </p>
+                      <p className="text-sm text-orange-800">
+                        Siparişiniz seçtiğiniz adrese teslim edilecektir.
+                      </p>
                   </div>
 
                   <div className="pb-4">

--- a/components/delivery-method-selector/address-form-modal.tsx
+++ b/components/delivery-method-selector/address-form-modal.tsx
@@ -146,9 +146,9 @@ export function AddressFormModal({
             <div className="flex-shrink-0 w-5 h-5 bg-orange-100 rounded-full flex items-center justify-center mt-0.5">
               <span className="text-orange-600 text-xs font-bold">!</span>
             </div>
-            <p className="text-sm text-orange-800">
-              Şiparisiniz seçtiğiniz adrese teslim edilecektir.
-            </p>
+              <p className="text-sm text-orange-800">
+                Siparişiniz seçtiğiniz adrese teslim edilecektir.
+              </p>
           </div>
 
           <div className="pb-4">


### PR DESCRIPTION
## Summary
- fix typos in Turkish address warning

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527e50e05883328839995bc15135b1