### PR TITLE
Add map cleanup effect

### DIFF
--- a/components/delivery-method-selector/map-component.tsx
+++ b/components/delivery-method-selector/map-component.tsx
@@ -149,6 +149,28 @@ export function MapComponent({
     }
   }, [center, map, marker]);
 
+  // Cleanup map and markers on unmount or when dependencies change
+  useEffect(() => {
+    return () => {
+      branchMarkers.forEach((bm) => {
+        if (bm) {
+          bm.off && bm.off();
+          bm.remove && bm.remove();
+        }
+      });
+
+      if (marker) {
+        marker.off && marker.off();
+        marker.remove && marker.remove();
+      }
+
+      if (map) {
+        map.off && map.off();
+        map.remove();
+      }
+    };
+  }, [map, marker, branchMarkers]);
+
   const handleZoomIn = () => {
     if (map) {
       map.setZoom(map.getZoom() + 1);


### PR DESCRIPTION
## Summary
- add a cleanup `useEffect` for Leaflet maps

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527ed0ad54833284ce94afd8042d2e