### PR TITLE
Fix mobile filter width

### DIFF
--- a/components/campaign-filter-sidebar.tsx
+++ b/components/campaign-filter-sidebar.tsx
@@ -61,7 +61,7 @@ export function CampaignFilterSidebar({ isOpen, onClose, onFilterChange }: Campa
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-[9997] md:relative md:bg-transparent" onClick={onClose}>
       <div
-        className="fixed right-0 top-0 h-full w-80 bg-white shadow-lg md:relative md:w-full md:shadow-none md:z-0 overflow-y-auto"
+        className="fixed right-0 top-0 h-full w-full bg-white shadow-lg md:relative md:w-80 md:shadow-none md:z-0 overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-6 min-h-full">

--- a/components/extras-filter-sidebar.tsx
+++ b/components/extras-filter-sidebar.tsx
@@ -61,7 +61,7 @@ export function ExtrasFilterSidebar({ isOpen, onClose, onFilterChange }: ExtrasF
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-[9997] md:relative md:bg-transparent" onClick={onClose}>
       <div
-        className="fixed right-0 top-0 h-full w-80 bg-white shadow-lg md:relative md:w-full md:shadow-none md:z-0 overflow-y-auto"
+        className="fixed right-0 top-0 h-full w-full bg-white shadow-lg md:relative md:w-80 md:shadow-none md:z-0 overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-6 min-h-full">

--- a/components/filter-sidebar.tsx
+++ b/components/filter-sidebar.tsx
@@ -60,7 +60,7 @@ export function FilterSidebar({ isOpen, onClose, onFilterChange }: FilterSidebar
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 md:relative md:bg-transparent">
-      <div className="fixed right-0 top-0 h-full w-80 bg-white shadow-lg md:relative md:w-full md:shadow-none">
+      <div className="fixed right-0 top-0 h-full w-full bg-white shadow-lg md:relative md:w-80 md:shadow-none">
         <div className="p-6">
           <div className="flex items-center justify-between mb-6 md:hidden">
             <h2 className="text-xl font-bold">Filtreler</h2>

--- a/components/pizza-filter-sidebar.tsx
+++ b/components/pizza-filter-sidebar.tsx
@@ -90,7 +90,7 @@ export function PizzaFilterSidebar({
       onClick={onClose}
     >
       <div
-        className="fixed right-0 top-0 h-full w-80 bg-white shadow-lg md:relative md:w-full md:shadow-none md:z-0 overflow-y-auto"
+        className="fixed right-0 top-0 h-full w-full bg-white shadow-lg md:relative md:w-80 md:shadow-none md:z-0 overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-6 min-h-full">


### PR DESCRIPTION
## Summary
- adjust mobile filter sidebars to use full width on small screens

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c868e3d4833299aed4cf5071c551